### PR TITLE
chore: remove provisional acount creation 

### DIFF
--- a/src/app/utils/waka.ts
+++ b/src/app/utils/waka.ts
@@ -125,18 +125,23 @@ export interface WakaInfo {
 export async function createWaka(
   email: string,
   name: string | null | undefined,
-  slackId: string | null | undefined,
+  slackId: string | null | undefined
 ): Promise<WakaInfo> {
   const password = crypto.randomUUID();
+
+  if (!slackId) {
+    const error = new Error("No slackId found while creating Waka account");
+    console.error(error);
+    throw error;
+  }
 
   const payload = {
     location: "America/New_York",
     email,
     password,
     password_repeat: password,
-    name: name ?? "",
-    username:
-      slackId ?? `$high-seas-provisional-${email.replace("+", "$plus$")}`,
+    name: name ?? slackId,
+    username: slackId,
   };
 
   const signup = await fetch("https://waka.hackclub.com/signup", {
@@ -170,7 +175,7 @@ export async function getWakaSessions(): Promise<{
 
   if (!username || !key) {
     const err = new Error(
-      "While getting sessions, no waka info could be found or created",
+      "While getting sessions, no waka info could be found or created"
     );
     console.error(err);
     throw err;
@@ -187,7 +192,7 @@ export async function getWakaSessions(): Promise<{
         // Note, this should probably just be an admin token in the future.
         Authorization: `Bearer ${key}`,
       },
-    },
+    }
   );
 
   let summaryResJson;


### PR DESCRIPTION
also throws an error now if the slackid doesn't exist