### PR TITLE
Remove 33d6a6 from showing on card updates

### DIFF
--- a/src/app/harbor/signpost/feed-items.tsx
+++ b/src/app/harbor/signpost/feed-items.tsx
@@ -42,7 +42,6 @@ export default function FeedItems() {
               <br />
               <span style={{ color: `#${item.textColor}` }}>
                 <Markdown>{item.content}</Markdown>
-                {item.backgroundColor}
               </span>
             </p>
           </JaggedCardSmall>


### PR DESCRIPTION
<img width="906" alt="Screenshot 2024-11-05 at 14 46 05" src="https://github.com/user-attachments/assets/0b0715ac-3628-4377-b181-9625be46982c">

Previously this css color was showing up in text!