### PR TITLE
Initial toggle to hide instructions for waka

### DIFF
--- a/src/app/harbor/signpost/feed-items.tsx
+++ b/src/app/harbor/signpost/feed-items.tsx
@@ -28,7 +28,6 @@ export default function FeedItems() {
           <JaggedCardSmall
             key={idx}
             bgColor={`#${item.backgroundColor}`}
-            className="px-6 py-4"
           >
             <p style={{ color: `#${item.textColor}` }}>
               <span className="text-xl">

--- a/src/app/harbor/signpost/signpost.tsx
+++ b/src/app/harbor/signpost/signpost.tsx
@@ -55,6 +55,9 @@ export default function Signpost() {
         .map((s) => Number(s))
     : null;
 
+  // Show or hide instructions for installing hakatime
+  const [showInstructions, setShowInstructions] = useState(!hasHb);
+
   return (
     <motion.div
       initial={{ opacity: 0 }}
@@ -67,7 +70,7 @@ export default function Signpost() {
 
       <Verification />
 
-      <div className="text-center">
+      <div className="text-center mb-4">
         <h2 className="mt-12 font-heading text-2xl font-bold mb-4">Stats</h2>
         <p>
           {hasHb ? (
@@ -86,9 +89,9 @@ export default function Signpost() {
         </p>
       </div>
 
-      <JaggedCard shadow={false}>
+      <JaggedCard shadow={false} small={!showInstructions}>
         {wakaKey ? (
-          <Platforms wakaKey={wakaKey} hasHb={hasHb} />
+          <Platforms wakaKey={wakaKey} hasHb={hasHb} showInstructions={showInstructions} setShowInstructions={setShowInstructions} />
         ) : (
           <p>Loading Hakatime token...</p>
         )}

--- a/src/app/harbor/signpost/verification.tsx
+++ b/src/app/harbor/signpost/verification.tsx
@@ -87,7 +87,7 @@ export default function Verification() {
   const { message, redirect } = getVerificationMessage(status, reason);
 
   return (
-    <JaggedCardSmall bgColor={"#EF4444"} className="px-6 py-4 text-white">
+    <JaggedCardSmall bgColor={"#EF4444"} className="text-white">
       <p style={{ textWrap: "pretty" }}>{message}</p>
       {redirect ? (
         <Link

--- a/src/app/utils/wakatime-setup/platforms.tsx
+++ b/src/app/utils/wakatime-setup/platforms.tsx
@@ -6,8 +6,7 @@ import {
 } from "@/app/utils/wakatime-setup/tutorial-utils.client";
 import { AnimatePresence, motion } from "framer-motion";
 
-export default function Platforms({ wakaKey, hasHb }: { wakaKey: string, hasHb: boolean }) {
-  const [showInstructions, setShowInstructions] = useState(!hasHb);
+export default function Platforms({ wakaKey, hasHb, showInstructions, setShowInstructions }: { wakaKey: string, hasHb: boolean, showInstructions: boolean, setShowInstructions: any }) {
   const [showAllPlatforms, setShowAllPlatforms] = useState(false);
   const [userOs, setUserOs] = useState<Os>("unknown");
 
@@ -110,12 +109,12 @@ api_key = ${wakaKey}`}
             </motion.div>)}
         </AnimatePresence>
       ) : (
-        <p className="text-xs mt-4">
+        <p className="text-sm m-2">
           <span
             className="underline cursor-pointer"
             onClick={() => setShowInstructions(true)}
           >
-            View Hakatime instructions
+            {"> Show Hakatime install instructions"}
           </span>
         </p>
       )}

--- a/src/components/jagged-card-small.tsx
+++ b/src/components/jagged-card-small.tsx
@@ -51,7 +51,7 @@ const JaggedCardSmall = ({
 }) => {
   return (
     <div
-      className="relative w-full"
+      className="relative w-full px-6 py-4"
       {...props}
       style={{
         filter: shadow ? `drop-shadow(0 0 1rem ${bgColor}80)` : "",

--- a/src/components/jagged-card.tsx
+++ b/src/components/jagged-card.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import JaggedCardSmall from "./jagged-card-small";
 
 const Svg = ({ bgColor }) => (
   <svg
@@ -57,8 +58,22 @@ const JaggedCard = ({
   className = "",
   bgColor = "#48BBFE",
   shadow = true,
+  small = false,
   ...props
 }) => {
+  if (small) {
+    return (
+      <JaggedCardSmall
+        className={className}
+        bgColor={bgColor}
+        shadow={shadow}
+        {...props}
+      >
+        {children}
+      </JaggedCardSmall>
+    )
+  }
+
   return (
     <div
       className="relative w-full"


### PR DESCRIPTION
Now users who already have a heartbeat will have their waka instructions collapsed by default so the signpost updates can just barely fit above the fold:

<img width="1448" alt="Screenshot 2024-11-06 at 10 46 51" src="https://github.com/user-attachments/assets/16da1e80-7bb1-484e-8ab8-f8f1db2270d7">

The instructions are still togglable and will come back from the collapse when clicked:

<img width="1454" alt="Screenshot 2024-11-06 at 10 46 58" src="https://github.com/user-attachments/assets/ac62112d-b06a-449d-afea-04c33248c116">
