### PR TITLE
Move signpost to client-side fetching

### DIFF
--- a/src/app/harbor/signpost/feed-items.tsx
+++ b/src/app/harbor/signpost/feed-items.tsx
@@ -1,24 +1,22 @@
 'use client'
 
-import { SignpostFeedItem } from '@/app/utils/data'
+import { fetchSignpostFeed, SignpostFeedItem } from '@/app/utils/data'
 import JaggedCardSmall from '@/components/jagged-card-small'
-import Cookies from 'js-cookie'
+import { useEffect } from 'react'
 import Markdown from 'react-markdown'
+import useLocalStorageState from '../../../../lib/useLocalStorageState'
 
 export default function FeedItems() {
-  const cookie = Cookies.get('signpost-feed')
-  if (!cookie) return null
 
-  let feedItems: SignpostFeedItem[]
-  try {
-    feedItems = JSON.parse(cookie).sort((a, b) => a?.autonumber < b?.autonumber)
-  } catch (e) {
-    console.error("Could't parse signpost feed cookie into JSON:", e)
-    return null
-  }
+  const [feedItems, setFeedItems] = useLocalStorageState<SignpostFeedItem[]>([])
+
+  useEffect(() => {
+    fetchSignpostFeed().then(r => setFeedItems(r))
+  }, [])
 
   if (!feedItems || feedItems.length === 0) {
     return <p>No feed updates yet! Check back soon.</p>
+    return null
   }
 
   return (

--- a/src/app/harbor/signpost/feed-items.tsx
+++ b/src/app/harbor/signpost/feed-items.tsx
@@ -7,11 +7,10 @@ import Markdown from 'react-markdown'
 import useLocalStorageState from '../../../../lib/useLocalStorageState'
 
 export default function FeedItems() {
-
   const [feedItems, setFeedItems] = useLocalStorageState<SignpostFeedItem[]>([])
 
   useEffect(() => {
-    fetchSignpostFeed().then(r => setFeedItems(r))
+    fetchSignpostFeed().then((r) => setFeedItems(r))
   }, [])
 
   if (!feedItems || feedItems.length === 0) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -31,6 +31,7 @@ export async function userPageMiddleware(request: NextRequest) {
     const shipyardPage = request.nextUrl.pathname.startsWith('/shipyard')
     if (shipyardPage && !request.cookies.get('ships')) {
       const ships = await fetchShips(slackId, 2)
+      console.log(ships.map((s) => s.title))
       console.log("ships too big:", tooBig(ships))
       response.cookies.set({
         name: 'ships',

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,7 +16,7 @@ function checkSize(obj: any) {
 function tooBig(obj: any) {
   console.log(checkSize(obj))
   // https://vercel.com/docs/errors/REQUEST_HEADER_TOO_LARGE
-  return checkSize(obj) > 4096
+  return checkSize(obj) > 16384
 }
 
 export async function userPageMiddleware(request: NextRequest) {
@@ -30,7 +30,7 @@ export async function userPageMiddleware(request: NextRequest) {
   try {
     const shipyardPage = request.nextUrl.pathname.startsWith('/shipyard')
     if (shipyardPage && !request.cookies.get('ships')) {
-      const ships = await fetchShips(slackId, 3)
+      const ships = await fetchShips(slackId, 2)
       console.log("ships too big:", tooBig(ships))
       response.cookies.set({
         name: 'ships',

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -37,6 +37,7 @@ export async function userPageMiddleware(request: NextRequest) {
     console.log('Checking for waka cookie')
     if (!request.cookies.get('waka')) {
       const wakaData = await fetchWaka(session)
+      console.log("found waka cookie")
       let expiration = 60 * 60 * 1000 // In 1 hour
       if (wakaData?.hasHb) {
         expiration = 7 * 24 * 60 * 60 * 1000 // In 7 days

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,6 +9,16 @@ import {
   person,
 } from './app/utils/data'
 
+function checkSize(obj: any) {
+  return Buffer.byteLength(JSON.stringify(obj))
+}
+
+function tooBig(obj: any) {
+  console.log(checkSize(obj))
+  // https://vercel.com/docs/errors/REQUEST_HEADER_TOO_LARGE
+  return checkSize(obj) > 4096
+}
+
 export async function userPageMiddleware(request: NextRequest) {
   const session = await getSession()
   const slackId = session?.slackId
@@ -21,6 +31,7 @@ export async function userPageMiddleware(request: NextRequest) {
     const shipyardPage = request.nextUrl.pathname.startsWith('/shipyard')
     if (shipyardPage && !request.cookies.get('ships')) {
       const ships = await fetchShips(slackId, 3)
+      console.log("ships too big:", tooBig(ships))
       response.cookies.set({
         name: 'ships',
         value: JSON.stringify(ships),
@@ -42,6 +53,7 @@ export async function userPageMiddleware(request: NextRequest) {
       if (wakaData?.hasHb) {
         expiration = 7 * 24 * 60 * 60 * 1000 // In 7 days
       }
+      console.log("waka too big:", tooBig(wakaData))
       response.cookies.set({
         name: 'waka',
         value: JSON.stringify(wakaData),
@@ -64,6 +76,7 @@ export async function userPageMiddleware(request: NextRequest) {
       const p = (await person()).fields
 
       const tickets = Number(p['settled_tickets'])
+      console.log("tickets too big:", tooBig(tickets))
       response.cookies.set({
         name: 'tickets',
         value: JSON.stringify(tickets),
@@ -78,6 +91,7 @@ export async function userPageMiddleware(request: NextRequest) {
       if (verificationStatus.startsWith('Eligible')) {
         verifExpiration = 24 * 60 * 60 * 1000 // In 1 day
       }
+      console.log("verification too big:", tooBig(verificationStatus))
       response.cookies.set({
         name: 'verification',
         value: JSON.stringify({
@@ -93,6 +107,7 @@ export async function userPageMiddleware(request: NextRequest) {
       if (academyCompleted) {
         acadExpiration = 7 * 24 * 60 * 60 * 1000 // In 7 days
       }
+      console.log("academy too big:", tooBig(academyCompleted))
       response.cookies.set({
         name: 'academy-completed',
         value: JSON.stringify(academyCompleted),

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -31,8 +31,8 @@ export async function userPageMiddleware(request: NextRequest) {
     const shipyardPage = request.nextUrl.pathname.startsWith('/shipyard')
     if (shipyardPage && !request.cookies.get('ships')) {
       const ships = await fetchShips(slackId, 2)
-      console.log(ships.map((s) => s.title))
       console.log("ships too big:", tooBig(ships))
+      ships.map(s => console.log(JSON.stringify(s, null, 2)))
       response.cookies.set({
         name: 'ships',
         value: JSON.stringify(ships),

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -53,24 +53,6 @@ export async function userPageMiddleware(request: NextRequest) {
     console.log('Middleware errored on waka cookie step', e)
   }
 
-  // Signpost base
-  try {
-    console.log('Checking for signpost-feed cookie')
-    const signpostPage = request.nextUrl.pathname.startsWith('/signpost')
-    if (signpostPage && !request.cookies.get('signpost-feed')) {
-      const signpostFeed = await fetchSignpostFeed()
-      response.cookies.set({
-        name: 'signpost-feed',
-        value: JSON.stringify(signpostFeed),
-        path: '/',
-        sameSite: 'strict',
-        expires: new Date(Date.now() + 30 * 60 * 1000), // In 30 minutes
-      })
-    }
-  } catch (e) {
-    console.log('Middleware errored on signpost-feed cookie step', e)
-  }
-
   // Person base
   try {
     if (


### PR DESCRIPTION
Adding this as a quick-fix to stop bricking the page. Real fix is for this data to be statically built with server-side data fetching