### PR TITLE
Fix hour count wraparound

### DIFF
--- a/lib/pluralize.js
+++ b/lib/pluralize.js
@@ -1,0 +1,10 @@
+// pluralize(1, 'apple') => '1 apple'
+// pluralize(2, 'apple') => '2 apples'
+// pluralize(2, 'apple', false) => 'apples'
+
+export default function pluralize(count, singular, includeCount = true) {
+  return (
+    (includeCount ? `${count} ` : '') +
+    (count === 1 ? singular : singular + 's')
+  )
+}

--- a/src/app/harbor/signpost/signpost.tsx
+++ b/src/app/harbor/signpost/signpost.tsx
@@ -10,6 +10,8 @@ import Cookies from 'js-cookie'
 import FeedItems from './feed-items'
 import { getWakaSessions } from '@/app/utils/waka'
 
+import pluralize from '../../../../lib/pluralize.js'
+
 export default function Signpost() {
   let wakaKey: string | null = null
   let hasHb: boolean | null = null
@@ -47,13 +49,13 @@ export default function Signpost() {
     })
   }, [])
 
-  const hms = wakaSessions
-    ? new Date(wakaSessions.reduce((a, p) => (a += p.total), 0) * 1_000)
-        .toISOString()
-        .slice(11, 19)
-        .split(':')
-        .map((s) => Number(s))
-    : null
+  const wakaDuration = wakaSessions?.reduce((a, p) => (a += p.total), 0)
+  const hms = { hours: 0, minutes: 0, seconds: 0 }
+  if (wakaDuration) {
+    hms.hours = Math.floor(wakaDuration / 3600)
+    hms.minutes = Math.floor((wakaDuration % 3600) / 60)
+    hms.seconds = wakaDuration % 10
+  }
 
   // Show or hide instructions for installing Hackatime
   const [showInstructions, setShowInstructions] = useState(!hasHb)
@@ -91,16 +93,16 @@ export default function Signpost() {
         <p className="text-md md:text-lg">
           {hasHb ? (
             <>
-              {hms ? (
+              {wakaDuration ? (
                 <p>
                   <span>
-                    You've logged {hms[0]} hour{hms[0] !== 1 ? 's' : ''},{' '}
-                    {hms[1]} minute{hms[1] !== 1 ? 's' : ''},{' '}
+                    You've logged {pluralize(hms.hours, 'hour')},{' '}
+                    {pluralize(hms.minutes, 'minute')},{' '}
                   </span>
                   <br className="sm:hidden"></br>
                   <span>
-                    and {hms[2]} second{hms[2] !== 1 ? 's' : ''} of coding time
-                    so far!
+                    and {pluralize(hms.seconds, 'second')} of coding time so
+                    far!
                   </span>
                 </p>
               ) : (


### PR DESCRIPTION
Fixes https://github.com/hackclub/high-seas/issues/721

Before my hours showed as "0":

<img width="916" alt="Screenshot 2024-11-15 at 00 04 51" src="https://github.com/user-attachments/assets/04ab78ac-7550-48e1-9601-2df5ad76151c">

Now I see my full "24":

<img width="878" alt="Screenshot 2024-11-15 at 00 52 45" src="https://github.com/user-attachments/assets/c64d611c-c3a1-48c7-93c8-e142654c18af">
