### PR TITLE
Hour tracking only shows on shipped projects

### DIFF
--- a/src/components/ui/ship-pill-cluster.tsx
+++ b/src/components/ui/ship-pill-cluster.tsx
@@ -18,7 +18,11 @@ export default function ShipPillCluster({
   const unit = ship.doubloonPayout == 1 || '1' ? 'Doubloon' : 'Doubloons'
   return (
     <>
-      <Pill msg={`${ship.total_hours?.toFixed(1) ?? 0} hr`} glyph="clock" />
+      {ship.shipStatus === 'shipped' ? (
+        <Pill msg={`${ship.total_hours?.toFixed(1) ?? 0} hr`} glyph="clock" />
+      ) : (
+        <Pill msg="pending ship" glyph="clock" />
+      )}
 
       {ship.shipStatus === 'shipped' &&
         (ship.voteRequirementMet ? (


### PR DESCRIPTION
<img width="586" alt="Screenshot 2024-11-20 at 12 19 53" src="https://github.com/user-attachments/assets/c54af03e-97b5-47ca-8867-f33191f68d22">
