### PR TITLE
Fixed duplicates in shop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 .pnp.js
 .yarn/install-state.gz
 package-lock.json
-
 # testing
 /coverage
 
@@ -39,3 +38,4 @@ next-env.d.ts
 yarn.lock
 
 .vscode
+.idea/

--- a/src/app/harbor/shop/shop-utils.ts
+++ b/src/app/harbor/shop/shop-utils.ts
@@ -22,6 +22,7 @@ export interface ShopItem {
   enabledIn: boolean | null
   enabledXx: boolean | null
   enabledCa: boolean | null
+  enabledAll: boolean | null
   priceUs: number
   priceGlobal: number
   fulfilledAtEnd: boolean
@@ -74,6 +75,7 @@ export async function getShop(): Promise<ShopItem[]> {
               enabledIn: Boolean(record.get('enabled_in')) as boolean,
               enabledXx: Boolean(record.get('enabled_xx')) as boolean,
               enabledCa: Boolean(record.get('enabled_ca')) as boolean,
+              enabledAll: Boolean(record.get("enabled_all")) as boolean,
               priceUs: Number(record.get('tickets_us')) as number,
               priceGlobal: Number(record.get('tickets_global')) as number,
               fulfilledAtEnd: Boolean(

--- a/src/app/harbor/shop/shop.tsx
+++ b/src/app/harbor/shop/shop.tsx
@@ -39,9 +39,7 @@ export default function Shop({ session }: { session: HsSession }) {
   }
 
   const filters = {
-    '0': (x: any) => {
-      return true
-    },
+    '0': (item: any) => item.enabledAll,
     '1': (item: any) => item.enabledUs,
     '2': (item: any) => item.enabledEu,
     '3': (item: any) => item.enabledIn,


### PR DESCRIPTION
Added enabled_all field, to only show products once, even when there is several versions of them, like RPI zero