### PR TITLE
Memoize person lookup

### DIFF
--- a/src/app/utils/data.ts
+++ b/src/app/utils/data.ts
@@ -123,8 +123,9 @@ export async function fetchShips(
 //#endregion
 
 //#region Person
+let personCache: any = null
 export async function person(): Promise<any> {
-  return new Promise((resolve, reject) => {
+  personCache ||= new Promise((resolve, reject) => {
     getSession().then(async (session) => {
       if (!session) return reject('No session present')
 
@@ -145,6 +146,7 @@ export async function person(): Promise<any> {
       resolve(record)
     })
   })
+  return await personCache
 }
 //#endregion
 


### PR DESCRIPTION
This brings down airtable hits for the person record from 6 to 1 on the signpost. Haven't tested other pages yet:
<img width="328" alt="Screenshot 2024-11-22 at 06 59 49" src="https://github.com/user-attachments/assets/6564b470-9fdd-413b-b8f7-efd8f6eeb84b">
<img width="328" alt="Screenshot 2024-11-22 at 07 01 14" src="https://github.com/user-attachments/assets/711cf27e-0b28-423a-b3b5-58f3da067342">
