### PR TITLE
Fix the low hour count popup to show actual error messages

### DIFF
--- a/src/app/harbor/shipyard/ships.tsx
+++ b/src/app/harbor/shipyard/ships.tsx
@@ -192,13 +192,15 @@ export default function Ships({
 
                   try {
                     setIsShipping(true)
-                    await stagedToShipped(s, ships)
-                    location.reload()
+                    const { error } = await stagedToShipped(s, ships)
+                    if (error) {
+                      setErrorModal(String(error))
+                    } else {
+                      location.reload()
+                    }
                   } catch (err: unknown) {
                     if (err instanceof Error) {
                       setErrorModal(err.message)
-                    } else {
-                      setErrorModal(String(err))
                     }
                   } finally {
                     setIsShipping(false)


### PR DESCRIPTION
Heads up that this error can only be caught if you run `bun run build; bun run start` instead of using `bun run dev`– turns out nextjs filters out error messages from server components in prod builds.

Before:
![image (13)](https://github.com/user-attachments/assets/a7f8ee5d-5a58-42a0-928a-351148351790)

After:
<img width="909" alt="Screenshot 2024-12-03 at 22 13 34" src="https://github.com/user-attachments/assets/dcd972bf-0b42-4af4-8ea1-4b1ab0eaa9af">
