### PR TITLE
Fix ship title changing or becoming blank

### DIFF
--- a/src/app/harbor/shipyard/ships.tsx
+++ b/src/app/harbor/shipyard/ships.tsx
@@ -194,7 +194,7 @@ export default function Ships({
               />
             </div>
             <h2 className="text-xl font-semibold text-left mb-2 sm:hidden block">
-              {s.title}
+              {latestShip.title}
             </h2>
           </div>
           <div className="flex-grow">


### PR DESCRIPTION
When the window is resized, the title of a ship will change or disappear.
Big:
![image](https://github.com/user-attachments/assets/d52c8be3-b531-4c84-95d3-b1ca2725f0d9)

Small:
![image](https://github.com/user-attachments/assets/d2e83f47-e3a7-4f97-b6bc-1c5caa1ecd5d)

Notice how the shipped catsay loses the exclamation mark, and the draft update just ceases to have a title
This fixes that by using the same title variable in both cases