### PR TITLE
Bump Next.js to 14.2.15 to Fix Authorization Bypass Vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "js-confetti": "^0.12.0",
     "js-cookie": "^3.0.5",
     "lucide-react": "^0.446.0",
-    "next": "14.2.13",
+    "next": "14.2.15",
     "next-plausible": "^3.12.2",
     "openai": "^4.68.4",
     "react": "^18",


### PR DESCRIPTION
Description:
This PR bumps the Next.js version from 14.2.13 to 14.2.15 to address a critical security vulnerability related to authorization bypass in middleware.

Vulnerability Details:
Issue:
If a Next.js application performs authorization based on the pathname in middleware, it was possible for unauthorized access to be granted in certain cases due to a flaw in Next.js’s middleware handling logic. 

Impact:
Unauthorized users could potentially access restricted resources by bypassing middleware-based authorization. Doesnt affect vercel though!

Resolution:
This issue has been resolved in Next.js version 14.2.15. Updating to this version ensures proper authorization checks are enforced by middleware.

https://osv.dev/vulnerability/GHSA-7gfc-8cq8-jh5f