### PR TITLE
Remove "Holiday delay" section in shop

### DIFF
--- a/src/app/harbor/shop/shop.tsx
+++ b/src/app/harbor/shop/shop.tsx
@@ -78,14 +78,6 @@ export default function Shop({ session }: { session: HsSession }) {
         <p className="text-xl animate-pulse mb-6 rotate-[-7deg] inline-block">
           {bannerText}
         </p>
-
-        {!isTutorial && (
-          <JaggedCardSmall bgColor="#EF4444" className="text-white">
-            Heads up, the elves that run the shop are only part time and will be
-            busy with their other job in the north pole from Dec 21 - Jan 2nd.
-            You can still order, but prize fulfillment is delayed.
-          </JaggedCardSmall>
-        )}
         <ShopkeeperComponent />
         <br />
         <Progress val={favouriteItems} items={shopItems} />


### PR DESCRIPTION
Since the note is no longer up to date, it should be removed (>2nd of Jan.)