### PR TITLE
fix: fix local storage check for us prices (check `'1'` rather than `1`)

### DIFF
--- a/src/app/harbor/tabs/tabs.tsx
+++ b/src/app/harbor/tabs/tabs.tsx
@@ -216,7 +216,7 @@ export default function Harbor({
   let usPrices = false
   try {
     usPrices =
-      JSON.parse(localStorage.getItem('shop.country.filter')!)?.value === 1
+      JSON.parse(localStorage.getItem('shop.country.filter')!)?.value === '1'
   } catch (e) {}
   const currentTix = Number(Cookies.get('tickets') ?? 0)
   const nextPrize: ShopItem = shopItems


### PR DESCRIPTION
currently it shows incorrect "... doubloons until next prize" since it uses global prices—even when the us region is selected:

<img width="894" alt="image" src="https://github.com/user-attachments/assets/b68b9f53-ff58-4dcc-b257-b1113d88011f" />
<img width="284" alt="image" src="https://github.com/user-attachments/assets/cc563aef-b42e-4797-9693-48136fe446a4" />

this is due to the local storage checking the result for `1` rather than `'1'`, since the local storage has the number stringified: 

<img width="398" alt="image" src="https://github.com/user-attachments/assets/ed61d96b-d726-468c-8a61-a5c2ecb98558" />
