### PR TITLE
Added overflow x as hidden in the layout file. 

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -57,7 +57,7 @@ export default function RootLayout({
         <meta name="apple-mobile-web-app-title" content="High Seas" />
         <link rel="manifest" href="/favicons/site.webmanifest" />
       </head>
-      <body className={`${mainFont.variable} antialiased`}>
+      <body className={`${mainFont.variable} antialiased overflow-x-hidden`}>
         <Nav />
         <main>{children}</main>
         <PlausibleProvider domain="highseas.hackclub.com" />


### PR DESCRIPTION
This will hide the current overflow which is shown in [shipyard](https://highseas.hackclub.com/shipyard). Adding this has no problem on the other children of the website as they will simply overflow and this will not affect any of those properties. It could be great if it can be deployed first. 