### PR TITLE
Change initial zoom of Mystic Tavern map

### DIFF
--- a/src/app/harbor/tavern/map.tsx
+++ b/src/app/harbor/tavern/map.tsx
@@ -12,7 +12,7 @@ import { MapContainer, TileLayer, Marker, useMap, Tooltip } from 'react-leaflet'
 import 'leaflet/dist/leaflet.css'
 import { Card } from '@/components/ui/card'
 
-const MAP_ZOOM = 11,
+const MAP_ZOOM = 2,
   MAP_CENTRE: LatLngExpression = [0, 0]
 
 export default function Map() {


### PR DESCRIPTION
Sets the initial Leaflet map zoom to 2 so that people without geolocation services or choose to not enable them can clearly see the whole map with markers. I was confused for a while staring at the solid gray ocean at [0, 0] until I realized that I have to zoom out many times to see any useful information.