### PR TITLE
Fixed ships awaiting payout

### DIFF
--- a/src/app/utils/data.ts
+++ b/src/app/utils/data.ts
@@ -60,7 +60,6 @@ export interface Ship extends EditableShipFields {
   yswsType: YswsType
   feedback: string | null
   isInYswsBase: boolean
-  hidden: boolean
 }
 export interface EditableShipFields {
   title: string
@@ -143,7 +142,6 @@ export async function fetchShips(
       yswsType: r.fields.yswsType,
       feedback: r.fields.ai_feedback_summary,
       isInYswsBase: Boolean(r.fields.has_ysws_submission_id),
-      hidden: Boolean(r.fields.hidden),
     }
 
     return ship

--- a/src/app/utils/data.ts
+++ b/src/app/utils/data.ts
@@ -60,6 +60,7 @@ export interface Ship extends EditableShipFields {
   yswsType: YswsType
   feedback: string | null
   isInYswsBase: boolean
+  hidden: boolean
 }
 export interface EditableShipFields {
   title: string
@@ -142,6 +143,7 @@ export async function fetchShips(
       yswsType: r.fields.yswsType,
       feedback: r.fields.ai_feedback_summary,
       isInYswsBase: Boolean(r.fields.has_ysws_submission_id),
+      hidden: Boolean(r.fields.hidden),
     }
 
     return ship

--- a/src/components/ui/ship-pill-cluster.tsx
+++ b/src/components/ui/ship-pill-cluster.tsx
@@ -56,7 +56,7 @@ export default function ShipPillCluster({
       {chain[0].shipStatus === 'shipped' ? (
         <>
           {allShipsHaveVoteRequirementMet ? (
-            chain.at(-1)?.doubloonPayout != null ? (
+            chain.at(-1)?.matchups_count >= 10 || chain.at(-1)?.hidden ? (
               <Pill
                 classes={`${transparent && 'bg-white/15 text-white'} ${size === 'small' ? 'text-xs' : ''}`}
                 msg={pluralize(roundedPayout, 'doubloon', true)}

--- a/src/components/ui/ship-pill-cluster.tsx
+++ b/src/components/ui/ship-pill-cluster.tsx
@@ -56,7 +56,7 @@ export default function ShipPillCluster({
       {chain[0].shipStatus === 'shipped' ? (
         <>
           {allShipsHaveVoteRequirementMet ? (
-            chain.at(-1)?.matchups_count >= 10 || chain.at(-1)?.hidden ? (
+            chain.at(-1).paidOut == true ? (
               <Pill
                 classes={`${transparent && 'bg-white/15 text-white'} ${size === 'small' ? 'text-xs' : ''}`}
                 msg={pluralize(roundedPayout, 'doubloon', true)}


### PR DESCRIPTION
Earlier because of using adjusted_payout, payout was set to 0 instead of null, so ships awaiting payouts didn't show how many matchups are left, but just "0 doubloons".
Changed it, while making sure that ships that were hidden and didn't go through 10 matchups (so usually getting caught on fraud before payout) won't show negative matchups remaining
![image](https://github.com/user-attachments/assets/4e27ca9b-39c6-499c-b50e-d92f54ed8cf9)
