### PR TITLE
Remove the ability to ship local files as a demo

### DIFF
--- a/src/app/harbor/shipyard/new-ship-form.tsx
+++ b/src/app/harbor/shipyard/new-ship-form.tsx
@@ -165,6 +165,15 @@ export default function NewShipForm({
       return
     }
 
+    if (deploymentUrl.startsWith('file://')) {
+      toast({
+        title: "Local file URLs aren't allowed",
+        description: 'You cannot use a local file as a demo. Try using #cdn instead to host a video or vercel for a deployed project!',
+      })
+      setStaging(false)
+      return
+    }
+
     const repoUrl = formData.get('repo_url') as string
     if (usedRepos.includes(repoUrl)) {
       toast({

--- a/src/app/harbor/shipyard/new-ship-form.tsx
+++ b/src/app/harbor/shipyard/new-ship-form.tsx
@@ -168,7 +168,8 @@ export default function NewShipForm({
     if (deploymentUrl.startsWith('file://')) {
       toast({
         title: "Local file URLs aren't allowed",
-        description: 'You cannot use a local file as a demo. Try using #cdn instead to host a video or vercel for a deployed project!',
+        description: 
+          "You cannot use a local file as a demo. Try using #cdn instead to host a video or vercel for a deployed project!",
       })
       setStaging(false)
       return

--- a/src/app/harbor/shipyard/new-ship-form.tsx
+++ b/src/app/harbor/shipyard/new-ship-form.tsx
@@ -168,8 +168,8 @@ export default function NewShipForm({
     if (deploymentUrl.startsWith('file://')) {
       toast({
         title: "Local file URLs aren't allowed",
-        description: 
-          "You cannot use a local file as a demo. Try using #cdn instead to host a video or vercel for a deployed project!",
+        description:
+          'You cannot use a local file as a demo. Try using #cdn instead to host a video or vercel for a deployed project!',
       })
       setStaging(false)
       return


### PR DESCRIPTION
Doesn't let a user ship a project if they try to submit a local file instead of a video or deployment link.